### PR TITLE
We had symlinks in the backend from forever ago

### DIFF
--- a/backend/public/assets
+++ b/backend/public/assets
@@ -1,1 +1,0 @@
-../../frontend/bin/assets

--- a/backend/public/fonts
+++ b/backend/public/fonts
@@ -1,1 +1,0 @@
-../../frontend/bin/fonts

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -1,1 +1,0 @@
-../../frontend/bin/index.html


### PR DESCRIPTION
They also complicate the xing-framework release process; removing them
breaks no specs.