### PR TITLE
Make allowed origins configurable

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -58,9 +58,10 @@ module APP_MODULE
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
     config.site_title = "Another Quality Xing App"
+    allowed_origins = instance.secrets.allowed_origins
     config.middleware.insert_before Rack::Runtime, Rack::Cors do
         allow do
-            origins '*'
+            origins allowed_origins
             resource '*',
             :headers => :any,
             :expose => ['Location', 'access-token', 'token-type', 'client', 'expiry', 'uid'],

--- a/backend/config/secrets.yml.ci
+++ b/backend/config/secrets.yml.ci
@@ -17,6 +17,7 @@ test: &test
     password: password
   sitemap_base_url: http://localhost:3000/
   asset_host: http://localhost:3000/
+  allowed_origins: '*'
 
 development:
   <<: *test

--- a/backend/config/secrets.yml.example
+++ b/backend/config/secrets.yml.example
@@ -11,8 +11,8 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: 
-    deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef 
+  secret_key_base:
+    deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
   smtp:
     address: smtp.CHANGEME.com
     port: 587
@@ -32,10 +32,11 @@ development:
     password: password
   sitemap_base_url: http://localhost:3000/
   asset_host: http://localhost:3000/
+  allowed_origins: '*'
 
 test:
-  secret_key_base: 
-    deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef 
+  secret_key_base:
+    deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
   smtp:
     address: smtp.CHANGEME.com
     port: 587
@@ -52,6 +53,7 @@ test:
     password: password
   sitemap_base_url: http://localhost:3000/
   asset_host: http://localhost:3000/
+  allowed_origins: '*'
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
Oy... late to make this change but we'll get super nailed to the wall by the security community if we don't make this change.

Just lets allowed origins be configurable. Will need corresponding updates in the xing-framework templates.