### PR TITLE
Fix sass constants file to remove constants that aren't overriddent a…

### DIFF
--- a/frontend/src/styles/_constants.sass
+++ b/frontend/src/styles/_constants.sass
@@ -1,14 +1,30 @@
-$navbar_link_h_padding: 10px
-$navbar_link_v_padding: 10px
+// These are default constants for Xing
+// Uncomment to override any of these
 
-$call_to_action_color: #8E5
+// Breakpoints
+// $small: 500px
+// $medium: 768px
+// $desktop: 960px
 
-$error_bg_color: #e9b2b2
+// General content & nav layout
+// @include breakpoint-set('to ems', true)
+// $content_width: 960px
 
-@mixin error_notice_colors
-  border-width: 2px
-  border-style: solid
-  border-color: #ff4444
-  background: $error_bg_color
+// $main_background_color: #67c
 
-$link_color: #00e
+// $navbar_link_h_padding: 10px
+// $navbar_link_v_padding: 10px
+// $navbar_responsive_background_color: #ddd
+
+// Success color for forms, flashes etc.
+// $success_color: #0C0
+// $error_color: #C00
+
+// Admin menu & callout color
+// $admin_menu_height: 22px
+// $admin_background_color: #777755
+
+// $link_color: #00e
+// $call_to_action_color: #0e0
+
+// $text_highlight_color: #777755


### PR DESCRIPTION
…nd show other constants from framework sass

So there's no reason we should re-override constants that are already in the framework sass with the same values. We also make no mention of several framework constants.

Finally the mixin and one constant are used nowhere at all.
